### PR TITLE
Update Dockerfile with working default command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,6 @@
 FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- update Dockerfile to set `/app` workdir, install requirements, copy code and run `uvicorn`

## Testing
- `pytest -q`
- `docker build .` *(fails: command not found)*
- `docker-compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cd7d931c483339f91afda2536d51c