### PR TITLE
Fix async processing in worker tasks

### DIFF
--- a/app/workers/audio_worker.py
+++ b/app/workers/audio_worker.py
@@ -1,5 +1,6 @@
 from celery import current_task
 import logging
+import asyncio
 from app.workers.celery_app import celery_app
 from app.services.audio_processor import AudioProcessor
 
@@ -15,8 +16,8 @@ def process_audio_file_task(self, file_path: str, case_id: str):
         
         self.update_state(state='PROGRESS', meta={'progress': 50, 'status': 'Transcribing audio'})
         
-        # Process the file
-        result = processor.process_audio_file(file_path, case_id)
+        # Process the file asynchronously
+        result = asyncio.run(processor.process_audio_file(file_path, case_id))
         
         self.update_state(state='PROGRESS', meta={'progress': 100, 'status': 'Audio processing complete'})
         

--- a/app/workers/image_worker.py
+++ b/app/workers/image_worker.py
@@ -1,5 +1,6 @@
 from celery import current_task
 import logging
+import asyncio
 from app.workers.celery_app import celery_app
 from app.services.image_processor import ImageProcessor
 
@@ -15,7 +16,8 @@ def process_image_file_task(self, file_path: str, case_id: str):
         
         self.update_state(state='PROGRESS', meta={'progress': 50, 'status': 'Performing OCR'})
         
-        result = processor.process_image_file(file_path, case_id)
+        # Process the file asynchronously
+        result = asyncio.run(processor.process_image_file(file_path, case_id))
         
         self.update_state(state='PROGRESS', meta={'progress': 100, 'status': 'Image processing complete'})
         

--- a/app/workers/video_worker.py
+++ b/app/workers/video_worker.py
@@ -1,5 +1,6 @@
 from celery import current_task
 import logging
+import asyncio
 from app.workers.celery_app import celery_app
 from app.services.video_processor import VideoProcessor
 
@@ -15,7 +16,8 @@ def process_video_file_task(self, file_path: str, case_id: str):
         
         self.update_state(state='PROGRESS', meta={'progress': 50, 'status': 'Processing video'})
         
-        result = processor.process_video_file(file_path, case_id)
+        # Process the file asynchronously
+        result = asyncio.run(processor.process_video_file(file_path, case_id))
         
         self.update_state(state='PROGRESS', meta={'progress': 100, 'status': 'Video processing complete'})
         


### PR DESCRIPTION
## Summary
- run async processor methods inside Celery workers using `asyncio.run`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bbb641760833382edd1e56efcbf5d