### PR TITLE
Improve Render deployment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,8 @@ TEMP_DIRECTORY=./data/temp_processing
 MAX_FILE_SIZE=500000000
 
 # OCR Settings
-TESSERACT_PATH=/opt/homebrew/bin/tesseract
+# Default path for Linux environments (e.g. Render). Use /opt/homebrew/bin/tesseract on macOS.
+TESSERACT_PATH=/usr/bin/tesseract
 OCR_LANGUAGE=eng
 OCR_CONFIDENCE_THRESHOLD=60.0
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ cd legal-discovery-analysis
 cp .env.example .env
 # Edit .env with your configuration
 docker-compose up --build
+
+### Render Deployment Notes
+- Set `TESSERACT_PATH` to `/usr/bin/tesseract` on Render or other Linux hosts.
+- Run the Celery worker alongside the API:
+  ```bash
+  docker-compose up worker
+  ```
 ```
 
 #### Option 2: Deploy to a remote host

--- a/app/config.py
+++ b/app/config.py
@@ -29,8 +29,9 @@ class Settings(BaseSettings):
     supported_video_formats: List[str] = [".mp4", ".avi", ".mov", ".wmv", ".flv", ".mkv"]
     supported_image_formats: List[str] = [".jpg", ".jpeg", ".png", ".tiff", ".bmp", ".pdf"]
     
-    # OCR Settings (M4 paths)
-    tesseract_path: str = "/opt/homebrew/bin/tesseract"  # M4 Homebrew path
+    # OCR Settings
+    # Default to the typical Linux path; override in .env for macOS/Homebrew.
+    tesseract_path: str = "/usr/bin/tesseract"
     ocr_language: str = "eng"
     ocr_confidence_threshold: float = 60.0
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,31 @@ services:
       - ENABLE_OCR=true
       - ENABLE_AUDIO_TRANSCRIPTION=true
 
+  worker:
+    build: .
+    command: celery -A app.workers.celery_app worker --loglevel=info
+    depends_on:
+      - redis
+    volumes:
+      - ./discovery_sets:/app/discovery_sets
+      - ./analysis_outputs:/app/analysis_outputs
+      - ./data:/app/data
+      - ./legal_discovery.db:/app/legal_discovery.db
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DATABASE_URL=sqlite:///./legal_discovery.db
+
   chroma:
     image: chromadb/chroma:latest
     ports:
       - "8001:8000"
     volumes:
       - chroma_data:/chroma/chroma
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
 
 volumes:
   chroma_data:

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -18,7 +18,9 @@ sudo apt-get install -y docker docker-compose
 git clone <repository-url>
 cd legal-discovery-analysis
 cp .env.example .env
-# Edit .env and set your OPENAI_API_KEY and any other secrets
+# Edit .env and set your OPENAI_API_KEY and any other secrets.
+# On Render, tesseract is usually located at `/usr/bin/tesseract`, so update
+# `TESSERACT_PATH` accordingly.
 ```
 
 ## 4. Start the application


### PR DESCRIPTION
## Summary
- set default Tesseract path for Linux and note macOS override
- add Celery worker and Redis services to `docker-compose.yml`
- mention Render-specific environment updates in docs and README

## Testing
- `pytest -q`
