### PR TITLE
Use headless OpenCV

### DIFF
--- a/requirements-mac.txt
+++ b/requirements-mac.txt
@@ -30,7 +30,7 @@ openpyxl
 
 # Image Processing & OCR
 pillow
-opencv-python
+opencv-python-headless
 pytesseract
 easyocr
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ openpyxl>=3.1.0
 
 # Image Processing & OCR (M4 optimized)
 pillow>=10.0.0
-opencv-python>=4.8.0  # M4 compatible
+opencv-python-headless>=4.8.0  # M4 compatible and avoids libGL
 pytesseract>=0.3.10
 # easyocr  # Install separately if needed
 scikit-learn>=1.3.0


### PR DESCRIPTION
## Summary
- replace `opencv-python` with `opencv-python-headless`
- keep Mac requirements consistent

## Testing
- `pytest -q`
- `docker build -t test-image .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d05c63da88333a7f2482c584a6339